### PR TITLE
allow indexes on mongodb

### DIFF
--- a/lib/databases/mongodb.js
+++ b/lib/databases/mongodb.js
@@ -178,12 +178,33 @@ module.exports = {
 
     },
 
+    // __ensureIndexes:__ this function is used to create indexes defined in repo.
+    // 
+    // `repo.ensureIndexes()` is run on repo.checkConnection()
+    ensureIndexes: function() {
+        var self = this;
+
+        if (!this.isConnected || !this.collectionName || !this.indexes) return;
+
+        this.indexes.forEach(function(index) {
+            var index, options;
+
+            index = index.index ? index.index : index;
+            options = index.options ? index.options : {};
+
+            self.client.ensureIndex(self.collectionName, index, options, function(err, indexName) {
+                // nothing todo.
+            });
+        });
+    },
+
     // __checkConnection:__ Use this function to check if all is initialized correctly.
     // 
     // `this.checkConnection()`
     checkConnection: function() {
         if(!this.collection) {
             this.collection = new mongo.Collection(this.client, this.collectionName);
+            this.ensureIndexes();
         }
     },
 


### PR DESCRIPTION
var repository = require('viewmodel').read
  , _ = require('lodash');

module.exports = repository.extend({

  collectionName: 'contact',
  indexes: [
    {profileId: 1},
    // or:
    { index: {profileId: 1}, options: {} }
  ],
