### PR TITLE
InMemory store now correctly instantiates with collectionName

### DIFF
--- a/lib/databases/inmemory.js
+++ b/lib/databases/inmemory.js
@@ -12,6 +12,12 @@ var util = require('util'),
 
 function InMemory(options) {
   Repository.call(this, options);
+  
+  if (options) {
+      // set collectionName
+      if (!options.collectionName) console.log('Warning: you did not provide a collectionName to the inMemory store.');
+      this.collectionName = options.collectionName;
+  }  
 }
 
 util.inherits(InMemory, Repository);
@@ -161,4 +167,4 @@ _.extend(Repository.prototype, {
 
 });
 
-module.exports = Repository;
+module.exports = InMemory;


### PR DESCRIPTION
Fix for #45 

I also added a console.log warning when no collectionName is provided. I'm not sure you are open to having it there, so let me know and I will adjust the PR if needed.