### PR TITLE
Switching DynamoDB scan to FilterExpression

### DIFF
--- a/lib/databases/dynamodb.js
+++ b/lib/databases/dynamodb.js
@@ -295,22 +295,57 @@ _.extend(DynamoDB.prototype, {
   }
 });
 
+function createDynamoParams(obj, objPrefix) {
+  objPrefix = objPrefix ? objPrefix + '.#' : '#';
+
+  return _.reduce(obj, (result, value, key) => {
+      var valueSearchedFor = obj[key];
+      var dotNotatedTargetAttribute = objPrefix + key;
+
+      if(_.isPlainObject(valueSearchedFor)) {
+          result = _.merge(result, createDynamoParams(valueSearchedFor, dotNotatedTargetAttribute));
+          result.expressionAttributeNames['#' + key] = key;
+      } else {
+          var attributeVariable = ':' + dotNotatedTargetAttribute.replace(/(\.|#)/g, '');
+          var attributeValueKey = '#' + key;
+
+          if (result.filterExpression !== '') {
+            result.filterExpression = result.filterExpression + ' AND ';
+          }
+
+          result.filterExpression = result.filterExpression + dotNotatedTargetAttribute + ' = ' + attributeVariable;
+          result.expressionAttributeValues[attributeVariable] = valueSearchedFor;
+          result.expressionAttributeNames['#' + key] = key;
+      }
+
+      return result;
+  },
+  {
+    expressionAttributeNames: {},
+    filterExpression: '',
+    expressionAttributeValues: {}
+  })
+};
+
 function queryToScanParams(tableName, query, queryOptions){
   var limit = queryOptions.skip + queryOptions.limit;
-  var scanFilter = _.reduce(query, function(result, value, key) {
-    result[key] = {
-      ComparisonOperator: 'EQ',
-      AttributeValueList: [ value]
-    };
-    return result;
-  }, {});
   var params = {
-      TableName: tableName,
-      ScanFilter: scanFilter
-  };
-  if(limit > 0){
-    return _.set(params, 'Limit', limit);
+    TableName: tableName,
   }
+
+  if (limit > 0) {
+    params.Limit = limit;
+  }
+
+  if (_.isEmpty(query)) {
+    return params;
+  }
+
+  var dynamoParams = createDynamoParams(query);
+  params.FilterExpression = dynamoParams.filterExpression;
+  params.ExpressionAttributeNames = dynamoParams.expressionAttributeNames;
+  params.ExpressionAttributeValues = dynamoParams.expressionAttributeValues;
+
   return params;
 }
 

--- a/lib/databases/dynamodb.js
+++ b/lib/databases/dynamodb.js
@@ -298,7 +298,7 @@ _.extend(DynamoDB.prototype, {
 function createDynamoParams(obj, objPrefix) {
   objPrefix = objPrefix ? objPrefix + '.#' : '#';
 
-  return _.reduce(obj, (result, value, key) => {
+  return _.reduce(obj, function (result, value, key) {
       var valueSearchedFor = obj[key];
       var dotNotatedTargetAttribute = objPrefix + key;
 


### PR DESCRIPTION
So far the DynamoDB implementation was using the ScanFilter implementation of DynamoDB to scan tables and find objects based on queries.

This produces issues though once you want to scan for nested attributes in an object as ScanFilter is only able to perform a full equality check on objects of type "Map".

Amazon instead recommends to use FilterExpressions instead and ScanFilter has been indicated to be "legacy".
Details on the differences are provided here: http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.ScanFilter.html

With this PR scanning for nested objects in a DynamoDB should be possible and - for future implementations - more flexible as it can be extended to support more types of search queries.