### PR TITLE
Dynamodb filter expression fix

### DIFF
--- a/lib/databases/dynamodb.js
+++ b/lib/databases/dynamodb.js
@@ -303,17 +303,35 @@ function createDynamoParams(obj, objPrefix) {
       var dotNotatedTargetAttribute = objPrefix + key;
 
       if(_.isPlainObject(valueSearchedFor)) {
-          result = _.merge(result, createDynamoParams(valueSearchedFor, dotNotatedTargetAttribute));
-          result.expressionAttributeNames['#' + key] = key;
+        result.expressionAttributeNames['#' + key] = key;
+
+        const newCondition = createDynamoParams(valueSearchedFor, dotNotatedTargetAttribute);
+        result.expressionAttributeNames = _.merge(
+          result.expressionAttributeNames,
+          newCondition.expressionAttributeNames);
+
+        result.expressionAttributeValues = _.merge(
+          result.expressionAttributeValues,
+          newCondition.expressionAttributeValues);
+
+        if (!_.isEmpty(newCondition.filterExpression)) {
+          result.filterExpression = result.filterExpression.concat(
+            _.isEmpty(result.filterExpression) ? '' : ' AND ',
+            newCondition.filterExpression);
+        }
       } else {
           var attributeVariable = ':' + dotNotatedTargetAttribute.replace(/(\.|#)/g, '');
           var attributeValueKey = '#' + key;
 
           if (result.filterExpression !== '') {
-            result.filterExpression = result.filterExpression + ' AND ';
+            result.filterExpression = result.filterExpression.concat(' AND ');
           }
 
-          result.filterExpression = result.filterExpression + dotNotatedTargetAttribute + ' = ' + attributeVariable;
+          result.filterExpression = result.filterExpression.concat(
+            dotNotatedTargetAttribute,
+            ' = ',
+            attributeVariable);
+
           result.expressionAttributeValues[attributeVariable] = valueSearchedFor;
           result.expressionAttributeNames['#' + key] = key;
       }

--- a/lib/databases/dynamodb.js
+++ b/lib/databases/dynamodb.js
@@ -37,7 +37,7 @@ _.extend(DynamoDB.prototype, {
   connect: function(callback) {
     var self = this;
     self.client = new aws.DynamoDB(self.options.endpointConf);
-    self.documentClient = new aws.DynamoDB.DocumentClient(self.client);
+    self.documentClient = new aws.DynamoDB.DocumentClient({ service: self.client });
     self.isConnected = true;
     self.emit('connect');
     if (callback) callback(null, self);


### PR DESCRIPTION
With the last PR #55 a bug was introduced causing the DynamoDB FilterExpression getting overwritten when multiple conditions where used in a find() operation, causing the Scan to not return any results or even fail.
This PR fixes this behavior so that multiple conditions should be handled fine again.