### PR TITLE
elasticsearch6 driver bulkCommit implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Make shure you have installed the required driver, in this example run: 'npm ins
 currently supported by:
 - inmemory
 - mongodb
+- elasticsearch6
 
 
 ## mongodb

--- a/lib/databases/elasticsearch6.js
+++ b/lib/databases/elasticsearch6.js
@@ -218,16 +218,14 @@ _.extend(Elasticsearch.prototype, {
             obj = vm.attributes;
             bulkOperation.push(
               { index: { _index: self.indexAndTypeName, _type: self.indexAndTypeName, _id: vm.id, op_type: 'create' } },
-              obj,
-            );
+              obj);
             indexCount++;
             break;
           case 'update':
             obj = vm.attributes;
             bulkOperation.push(
               { update: { _index: self.indexAndTypeName, _type: self.indexAndTypeName, _id: vm.id, version: vm.version } },
-              { doc: obj },
-            );
+              { doc: obj });
             indexCount++;
             break;
           default:

--- a/lib/databases/elasticsearch6.js
+++ b/lib/databases/elasticsearch6.js
@@ -154,10 +154,6 @@ _.extend(Elasticsearch.prototype, {
 				},
 				function(err, res) {
 					if (err) {
-            console.log('---')
-            console.log(err, body)
-            console.log('---')
-    
             return callback(err);
 					}
 

--- a/lib/databases/elasticsearch6.js
+++ b/lib/databases/elasticsearch6.js
@@ -131,15 +131,19 @@ _.extend(Elasticsearch.prototype, {
 	},
 
 	find: function(query, queryOptions, callback) {
-		var self = this;
+    var self = this;
 
 		this.checkConnection(function(err) {
 			if (err) {
-				return callback(err);
+        return callback(err);
 			}
 
 			// only native search queries are supported for now
-			var body = _.merge({ query: query }, queryOptions);
+      var body = _.merge({ query: query }, queryOptions);
+      
+      // fix
+      if (_.isEmpty(body.query))
+        delete body.query;
 
 			self.client.search(
 				{
@@ -150,10 +154,14 @@ _.extend(Elasticsearch.prototype, {
 				},
 				function(err, res) {
 					if (err) {
-						return callback(err);
+            console.log('---')
+            console.log(err, body)
+            console.log('---')
+    
+            return callback(err);
 					}
 
-					// Map to view models
+          // Map to view models
 					var vms = _.map(res.hits.hits, function(res) {
 						var data = jsondate.parse(JSON.stringify(res._source));
 						var vm = new ViewModel(data, self, res._version);
@@ -170,7 +178,7 @@ _.extend(Elasticsearch.prototype, {
 	},
 
 	findOne: function(query, queryOptions, callback) {
-		queryOptions.size = 1;
+    queryOptions.size = 1;
 
 		this.find(query, queryOptions, function(err, vms) {
 			if (err) {
@@ -178,12 +186,107 @@ _.extend(Elasticsearch.prototype, {
 			}
 
 			if (vms.length === 0) {
-				return callback(null, null);
+        return callback(null, null);
 			}
 			callback(null, vms[0]);
 		});
 	},
 
+  bulkCommit: function (vms, callback) {
+    
+    if (!vms) return callback(new Error());
+
+    var self = this;
+
+    this.checkConnection(function(err) {
+			if (err) {
+				return callback(err);
+			}
+
+      var bulkOperation = [];
+      var vmMap = {};
+
+      var deletedCount = 0;
+      var indexCount = 0;
+
+      _.each(vms, function(vm) {
+        if (!vm.actionOnCommit) return;
+        vmMap[vm.id] = vm;
+        switch(vm.actionOnCommit) {
+          case 'delete':
+            if (vm.version === null) return;
+            bulkOperation.push({ delete: { _index: self.indexAndTypeName, _type: self.indexAndTypeName, _id: vm.id, version: vm.version } });
+            deletedCount++;
+            break;
+          case 'create':
+            obj = vm.attributes;
+            bulkOperation.push(
+              { index: { _index: self.indexAndTypeName, _type: self.indexAndTypeName, _id: vm.id, op_type: 'create' } },
+              obj,
+            );
+            indexCount++;
+            break;
+          case 'update':
+            obj = vm.attributes;
+            bulkOperation.push(
+              { update: { _index: self.indexAndTypeName, _type: self.indexAndTypeName, _id: vm.id, version: vm.version } },
+              { doc: obj },
+            );
+            indexCount++;
+            break;
+          default:
+            return;
+        }
+      });
+
+      self.client.bulk({
+        refresh: self.refresh,
+        waitForActiveShards: self.waitForActiveShards,
+        body: bulkOperation
+      }, function(err, result) {
+        if (err) {
+          return (err.status === 409) ? callback(new ConcurrencyError()) : callback(err);
+        }
+
+        // TODO: handle errors from result.erros
+        var resultDeleteCount = 0;
+        var resultIndexCount = 0;
+
+        var error = null;
+        _.each(result.items, function(op) {
+          // create/update - ie. index
+          var oper = op.index || op.create || op.update;
+          if (oper) {
+            if (oper.status === 409) {
+              error = new ConcurrencyError(oper._id);
+              return;
+            }            
+            resultIndexCount += 1;
+            vmMap[oper._id].version = oper._version;
+            vmMap[oper._id].actionOnCommit = 'update';
+            return;
+          }
+
+          // delete
+          if (op.delete) {
+            if (op.delete.status === 409) {
+              error = new ConcurrencyError(op.delete._id);
+              return;
+            }
+            resultDeleteCount += 1;
+            return;
+          }
+        });
+
+        if (error) return callback(error);
+        if (resultDeleteCount < deletedCount) return callback(new ConcurrencyError());
+        else if (resultIndexCount < indexCount) return callback(new ConcurrencyError());
+
+        callback(null, vms);
+      });
+    });
+  },
+  
 	commit: function(vm, callback) {
 		if (!callback) callback = dummyCallback;
 		if (!vm.actionOnCommit) return callback(new Error());
@@ -235,7 +338,7 @@ _.extend(Elasticsearch.prototype, {
 						function(err, res) {
 							if (err && err.status === 409) {
 								return callback(new ConcurrencyError());
-							}
+              }
 							vm.actionOnCommit = "update";
 							vm.version = res._version;
 							callback(err, vm);
@@ -248,7 +351,7 @@ _.extend(Elasticsearch.prototype, {
 		});
 	},
 
-	checkConnection: function(callback) {
+  checkConnection: function(callback) {
 		// callback is not always passed
 		if (!callback) callback = dummyCallback;
 
@@ -287,8 +390,8 @@ _.extend(Elasticsearch.prototype, {
 				body: self._buildCreateIndexBody()
 			},
 			function(err) {
-				if (err) {
-					self.indexAndTypeName = null;
+        if (err) {
+          self.indexAndTypeName = null;
 					var i = indexAndTypeNames.indexOf(self.indexAndTypeName);
 					if (i > -1) {
 						indexAndTypeNames.splice(i,1);
@@ -364,20 +467,19 @@ _.extend(Elasticsearch.prototype, {
 		body.mappings[self.indexAndTypeName] = {
 					dynamic_templates: [
 						{
-								non_analyzed_string: {
-									match: "*",
-									match_mapping_type: "string",
-									mapping: {
-									type: "text",
-										fields: {
-										keyword: {
-											type: 'keyword',
-											ignore_above: 256
-										}
-										},
-									index: "not_analyzed"
-									}
-								}
+              non_analyzed_string: {
+                match: "*",
+                match_mapping_type: "string",
+                mapping: {
+                type: "text",
+                  fields: {
+                    keyword: {
+                      type: 'keyword',
+                      ignore_above: 256
+                    }
+                  },
+                }
+              }
 						}
 					]
 				}

--- a/package.json
+++ b/package.json
@@ -74,6 +74,6 @@
     }
   ],
   "scripts": {
-    "test": "mocha"
+    "test": "mocha --exit"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "cradle": ">=0.6.7",
     "documentdb": ">=0.9.3",
     "doqmentdb": ">=0.2.7",
-    "elasticsearch": "13.x.x",
+    "elasticsearch": "14.x.x",
     "eslint": "^4.3.0",
     "eslint-plugin-no-only-tests": "^2.0.0",
     "expect.js": ">= 0.1.2",

--- a/test/repositoryWriteTest.js
+++ b/test/repositoryWriteTest.js
@@ -76,7 +76,8 @@ describe.only('Repository write', function() {
 
     describe('with options containing a type property with the value of', function() {
 
-      var types = ['inmemory', 'mongodb', 'tingodb', 'couchdb', 'redis', 'elasticsearch6', 'dynamodb'/*, 'elasticsearch', 'documentdb', 'azuretable'*/];
+      var types = ['elasticsearch6'];
+      //var types = ['inmemory', 'mongodb', 'tingodb', 'couchdb', 'redis', 'elasticsearch6', 'dynamodb'/*, 'elasticsearch', 'documentdb', 'azuretable'*/];
 
       types.forEach(function(type) {
 
@@ -800,7 +801,7 @@ describe.only('Repository write', function() {
 
                       }
 
-                      var bulkCommit = ['inmemory', 'mongodb'];
+                      var bulkCommit = ['inmemory', 'mongodb', 'elasticsearch6'];
 
                       if (_.includes(bulkCommit, type)) {
 
@@ -832,7 +833,17 @@ describe.only('Repository write', function() {
                                       expect(vms[2].actionOnCommit).to.eql('update');
                                       expect(vms).to.have.length(3);
 
-                                      dummyRepo.find({ bulk: true }, function (err, vms) {
+                                      var query = { bulk: true };
+                                      if (type === 'elasticsearch6')
+                                        query = {
+                                          bool: {
+                                            filter: [
+                                              { term: {bulk: true}}
+                                            ]
+                                          }
+                                        }
+      
+                                      dummyRepo.find(query, function (err, vms) {
                                         expect(err).not.to.be.ok();
                                         expect(vms).to.have.length(3);
   

--- a/test/repositoryWriteTest.js
+++ b/test/repositoryWriteTest.js
@@ -76,8 +76,7 @@ describe.only('Repository write', function() {
 
     describe('with options containing a type property with the value of', function() {
 
-      var types = ['elasticsearch6'];
-      //var types = ['inmemory', 'mongodb', 'tingodb', 'couchdb', 'redis', 'elasticsearch6', 'dynamodb'/*, 'elasticsearch', 'documentdb', 'azuretable'*/];
+      var types = ['inmemory', 'mongodb', 'tingodb', 'couchdb', 'redis', 'elasticsearch6', 'dynamodb'/*, 'elasticsearch', 'documentdb', 'azuretable'*/];
 
       types.forEach(function(type) {
 


### PR DESCRIPTION
A basic bulkCommit implementation.

Additional things that can be done: 

*. By huge amount of updates / vms ( ex: 500+, configurable of course) at once, the bulk operation can be split into smaller ones.

*. Introduction of BulkCommitError which is a container of multiple errors and can be feed it with individual errors for each vm ( will need some a little rework from the other implementations ).