### PR TITLE
Increase DynamoDB performance

### DIFF
--- a/lib/databases/dynamodb.js
+++ b/lib/databases/dynamodb.js
@@ -12,6 +12,7 @@ function DynamoDB(options) {
 
   var awsConf = {
     region: 'ap-southeast-2',
+    checkTablesOnlyOnce: true,
     endpointConf: {}
   };
 
@@ -211,6 +212,13 @@ _.extend(DynamoDB.prototype, {
   },
   checkConnection: function(callback) {
     var self = this;
+    
+    if (self.options.checkTablesOnlyOnce
+      && collections.indexOf(self.collectionName) >= 0) {
+        callback(null);
+        return;
+      }
+      
     createTableIfNotExists(
       self.client,
       CollectionTableDefinition(self.collectionName, self.options),

--- a/lib/databases/dynamodb.js
+++ b/lib/databases/dynamodb.js
@@ -12,7 +12,6 @@ function DynamoDB(options) {
 
   var awsConf = {
     region: 'ap-southeast-2',
-    checkTablesOnlyOnce: true,
     endpointConf: {}
   };
 
@@ -212,12 +211,10 @@ _.extend(DynamoDB.prototype, {
   },
   checkConnection: function(callback) {
     var self = this;
-    
-    if (self.options.checkTablesOnlyOnce
-      && collections.indexOf(self.collectionName) >= 0) {
-        callback(null);
-        return;
-      }
+
+    if (collections.indexOf(self.collectionName) >= 0) {
+      return callback(null);
+    }
       
     createTableIfNotExists(
       self.client,


### PR DESCRIPTION
So far any interaction with the DynamoDB tried to make sure that the table is existing, and if that is not the case it would create the table.

However as DynamoDB is an HTTP based API this would also always mean that an additional API request is done, increasing the time needed to handle events in the view model.

This PR makes sure that the table is only checked once for existence.