### PR TITLE
Adding SRV support for MongoDB

### DIFF
--- a/lib/databases/mongodb.js
+++ b/lib/databases/mongodb.js
@@ -16,7 +16,8 @@ function Mongo (options) {
   var defaults = {
     host: 'localhost',
     port: 27017,
-    dbName: 'context'//,
+    dbName: 'context',
+    protocol: 'mongodb://'
     // heartbeat: 60 * 1000
   };
 
@@ -58,15 +59,23 @@ _.extend(Mongo.prototype, {
         ? options.servers
         : [{host: options.host, port: options.port}];
 
-      var memberString = _(members).map(function(m) { return m.host + ':' + m.port; });
+      var memberString = _(members).map(function(m) {
+        if (options.protocol === 'mongodb+srv://') {
+          return m.host;
+        }
+
+        return m.host + ':' + m.port;
+      });
+
       var authString = options.username && options.password
         ? options.username + ':' + options.password + '@'
         : '';
+
       var optionsString = options.authSource
         ? '?authSource=' + options.authSource
         : '';
 
-      connectionUrl = 'mongodb://' + authString + memberString + '/' + options.dbName + optionsString;
+      connectionUrl = options.protocol + authString + memberString + '/' + options.dbName + optionsString;
     }
 
     var client;


### PR DESCRIPTION
This will enable MongoDB Atlas mongodb+srv:// URLs to be used without specifying the single servers, therefore being able to change and scale any MongoDB cluster without affecting any client.