### PR TITLE
Support mongo atomic operators

### DIFF
--- a/lib/databases/mongodb.js
+++ b/lib/databases/mongodb.js
@@ -295,7 +295,7 @@ _.extend(Mongo.prototype, {
           if (currentHash) {
             query._hash = currentHash;
           }
-          bulkOperation.push({ updateOne: { filter: query, update: obj, upsert: !currentHash } });
+          bulkOperation.push({ updateOne: { filter: query, update: {$set: obj}, upsert: !currentHash } });
           vm.actionOnCommit = 'update';
           modifiedCount++;
           break;


### PR DESCRIPTION
Mongo new version throwing "TypeError: Update document requires atomic operators"